### PR TITLE
Fix a typo in the caveman2-widgets.asd file

### DIFF
--- a/caveman2-widgets.asd
+++ b/caveman2-widgets.asd
@@ -23,5 +23,5 @@
                            (:file "navigation")
                            (:file "caveman2-widgets"))))
     :description "Weblocks like widgets for caveman2."
-    :long-description #.(read-file-string (subpathname *load-pathname* "README"))
+    :long-description #.(read-file-string (subpathname *load-pathname* "README.org"))
     :in-order-to ((test-op (test-op "caveman2-widgets-test"))))


### PR DESCRIPTION
The caveman2-widgets system defintion file had a typo in its :description slot
which was preventing the system from loading. It referred directly to a file
"README" on the *load-pathname* but that file was actually called "README.org".